### PR TITLE
fix: fix various typos

### DIFF
--- a/Sources/DataCacheKit/Cache.swift
+++ b/Sources/DataCacheKit/Cache.swift
@@ -68,8 +68,8 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
     private func _store(_ value: Value, for key: Key) -> Task<Void, Never> {
         queueingTask.enqueueAndReplacing { [weak self] in
             guard let self else { return }
-            async let memory: Void = await onMemory.store(value, for: key).value
-            async let disk: Void = await _storeToDisk(value, for: key)
+            async let memory: Void = onMemory.store(value, for: key).value
+            async let disk: Void = _storeToDisk(value, for: key)
 
             await memory
             await disk
@@ -87,8 +87,8 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
     private func _remove(for key: Key) -> Task<Void, Never> {
         queueingTask.enqueueAndReplacing { [weak self] in
             guard let self else { return }
-            async let memory: Void = await onMemory.remove(for: key).value
-            async let disk: Void = await onDisk.remove(for: key).value
+            async let memory: Void = onMemory.remove(for: key).value
+            async let disk: Void = onDisk.remove(for: key).value
 
             await memory
             await disk
@@ -106,8 +106,8 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
     private func _removeAll() -> Task<Void, Never> {
         queueingTask.enqueueAndReplacing { [weak self] in
             guard let self else { return }
-            async let memory: Void = await onMemory.removeAll().value
-            async let disk: Void = await onDisk.removeAll().value
+            async let memory: Void = onMemory.removeAll().value
+            async let disk: Void = onDisk.removeAll().value
 
             await memory
             await disk

--- a/Sources/DataCacheKit/Cache.swift
+++ b/Sources/DataCacheKit/Cache.swift
@@ -21,13 +21,13 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
         }
     }
 
-    private let onMemery: MemoryCache<Key, Value>
+    private let onMemory: MemoryCache<Key, Value>
     private let onDisk: DiskCache<Key>
 
     private var queueingTask: Task<Void, Never>?
 
     public init(options: Options, logger: Logger = .init(.disabled)) {
-        self.onMemery = .init(options: options.forMemory, logger: logger)
+        self.onMemory = .init(options: options.forMemory, logger: logger)
         self.onDisk = .init(options: options.forDisk, logger: logger)
         self.options = options
         self.logger = logger
@@ -40,7 +40,7 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
     public func value(for key: Key) async throws -> Value? {
         _ = await queueingTask?.result
 
-        if let value = await onMemery.value(for: key) {
+        if let value = await onMemory.value(for: key) {
             return value
         }
 
@@ -53,7 +53,7 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
             return try decoder.decode(Value.self, from: data)
         }()
 
-        await onMemery.store(value, for: key).value
+        await onMemory.store(value, for: key).value
         return value
     }
 
@@ -68,7 +68,7 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
     private func _store(_ value: Value, for key: Key) -> Task<Void, Never> {
         queueingTask.enqueueAndReplacing { [weak self] in
             guard let self else { return }
-            async let memory: Void = await onMemery.store(value, for: key).value
+            async let memory: Void = await onMemory.store(value, for: key).value
             async let disk: Void = await _storeToDisk(value, for: key)
 
             await memory
@@ -87,7 +87,7 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
     private func _remove(for key: Key) -> Task<Void, Never> {
         queueingTask.enqueueAndReplacing { [weak self] in
             guard let self else { return }
-            async let memory: Void = await onMemery.remove(for: key).value
+            async let memory: Void = await onMemory.remove(for: key).value
             async let disk: Void = await onDisk.remove(for: key).value
 
             await memory
@@ -106,7 +106,7 @@ public actor Cache<Key: Hashable & Sendable, Value: Codable & Sendable>: Caching
     private func _removeAll() -> Task<Void, Never> {
         queueingTask.enqueueAndReplacing { [weak self] in
             guard let self else { return }
-            async let memory: Void = await onMemery.removeAll().value
+            async let memory: Void = await onMemory.removeAll().value
             async let disk: Void = await onDisk.removeAll().value
 
             await memory

--- a/Sources/DataCacheKit/DiskCache.swift
+++ b/Sources/DataCacheKit/DiskCache.swift
@@ -272,7 +272,7 @@ extension DiskCache {
                         group.addTask { [change] }
                         continue
                     }
-                    let task = peformChange(change, with: url)
+                    let task = performChange(change, with: url)
                     group.addTask {
                         do {
                             try await task.value
@@ -292,7 +292,7 @@ extension DiskCache {
         }
     }
 
-    private func peformChange(_ change: Staging<Key>.Change, with url: URL) -> Task<Void, any Error> {
+    private func performChange(_ change: Staging<Key>.Change, with url: URL) -> Task<Void, any Error> {
         let task = Task {
             do {
                 switch change.operation {

--- a/Sources/DataCacheKit/DiskCache.swift
+++ b/Sources/DataCacheKit/DiskCache.swift
@@ -378,7 +378,7 @@ extension DiskCache {
                 try FileManager.default.removeItem(at: item.url)
                 size -= item.meta.totalFileAllocatedSize ?? 0
                 logger.debug(
-                    "\(self.logKey)sweeped item: \(item.url.lastPathComponent), size: \(item.meta.totalFileAllocatedSize ?? 0)"
+                    "\(self.logKey)swept item: \(item.url.lastPathComponent), size: \(item.meta.totalFileAllocatedSize ?? 0)"
                 )
                 return true
             } catch {

--- a/Sources/LRUCache/LRUCache.swift
+++ b/Sources/LRUCache/LRUCache.swift
@@ -12,7 +12,7 @@ public struct LRUCache<Key: Hashable & Sendable, Value: Sendable>: ~Copyable, Se
         nonmutating set { entries.withLock { $0.countLimit = newValue } }
     }
 
-    private let entries = OSAllocatedUnfairLock<Entiries>(initialState: .init())
+    private let entries = OSAllocatedUnfairLock<Entries>(initialState: .init())
 
     public init() {}
 
@@ -45,8 +45,8 @@ public struct LRUCache<Key: Hashable & Sendable, Value: Sendable>: ~Copyable, Se
     }
 
     public func removeAllValues() {
-        entries.withLock { entiries in
-            entiries.removeAll()
+        entries.withLock { entries in
+            entries.removeAll()
         }
     }
 }
@@ -83,7 +83,7 @@ private extension LRUCache {
         }
     }
 
-    struct Entiries: Sendable {
+    struct Entries: Sendable {
         var values: [Key: CacheEntry] = [:]
         var totalCost = 0
         var totalCostLimit = 0


### PR DESCRIPTION
## Summary
- Fix typo `onMemery` to `onMemory` in `Cache.swift`
- Fix typo `peformChange` to `performChange` in `DiskCache.swift`
- Fix typo `Entiries` to `Entries` in `LRUCache.swift`

## Test plan
- [x] Run `swift test` and verify all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)